### PR TITLE
Update language to support BlitzMax NG types

### DIFF
--- a/Syntaxes/BlitzMax.tmLanguage
+++ b/Syntaxes/BlitzMax.tmLanguage
@@ -1388,7 +1388,7 @@
 		<key>bmax_types</key>
 		<dict>
 			<key>match</key>
-			<string>(?i)\b(object|string|byte|short|int|long|float|double)\b</string>
+			<string>(?i)\b(object|string|byte|short|int|long|float|double|uint|ulong|size_t)\b</string>
 			<key>name</key>
 			<string>storage.type.blitzmax</string>
 		</dict>


### PR DESCRIPTION
As "BlitzMax" is no longer maintained and "BlitzMax NG" (https://blitzmax.org) took over it is time to add some support of the additional number types there: ULong, UInt and Size_T.